### PR TITLE
enable stickyHeader for SurveyDetail's Table

### DIFF
--- a/frontend/src/app/survey/SurveyDetail.js
+++ b/frontend/src/app/survey/SurveyDetail.js
@@ -110,7 +110,7 @@ function SurveyTableWithEverythingYouNeed({ assignments, survey, julianDays, cat
     React.useEffect(resetUpstreamCategory, [resetUpstreamCategory]);
 
     return (<>
-        <Table>
+        <Table stickyHeader>
             <TableHead>
                 <TableRow>
                     <TableCell component="th" scope="col" colSpan={2}>What?</TableCell>


### PR DESCRIPTION
This should be beneficial for tables having many rows.

I also considered adding a table footer with the same information (dates), but I think this PR is good enough.